### PR TITLE
Print usage if arguments are not provided

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -69,7 +69,8 @@ func main() {
 			}
 		}
 	} else {
-		fmt.Println("mode is not defined")
+    fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+    flag.PrintDefaults()
 	}
 
 }


### PR DESCRIPTION
Original

```
✗ ./log-generator
mode is not defined
```

Fixed version

```
✗ ./log-generator
Usage of ./log-generator:
  -count int
        log line count
  -mode string
        realtime or onetime
```
